### PR TITLE
refactor: calculator 페이지에서 데이터 페칭하는 부분 전체 hooks, tanstack query로 변경 완료

### DIFF
--- a/src/app/(features)/calculator/result-history-main/layout.tsx
+++ b/src/app/(features)/calculator/result-history-main/layout.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+
+const RootLayout = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+export default RootLayout;

--- a/src/app/(features)/calculator/result-history-main/page.tsx
+++ b/src/app/(features)/calculator/result-history-main/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 import {
   loadMyData,
-  // loadMyAllData,
-  // loadMyAvgData,
   loadRecentFiveMonthsEmissions,
   loadTopUsersData,
   loadUsersAvgData,
@@ -10,8 +8,6 @@ import {
 } from "@/hooks/monthlyData";
 import { MonthlyData } from "@/types/calculate";
 import React, { useEffect, useState } from "react";
-import Link from "next/link";
-import Image from "next/image";
 import { userStore } from "@/zustand/userStore";
 import { UserInfo } from "@/types/userInfoType";
 import { getUserInfo } from "@/api/user-action";
@@ -21,6 +17,11 @@ import Loading from "@/components/calculator/Loading";
 import CompareMonthlyEmissions from "@/components/calculator/CompareMonthlyEmissions";
 import HistoryCompareCard from "@/components/calculator/HistoryCompareCard";
 import HeaderTitle from "@/components/layout/HeaderTitle";
+import CalculateUserCard from "@/components/calculator/CalculateUserCard";
+import EmissionLeftSide from "@/components/calculator/EmissionHeader";
+import EmissionProgressBar from "@/components/calculator/EmissionProgressBar";
+import TreeCalculationCard from "@/components/calculator/TreeCalculationCard";
+import CompareChartLabel from "@/components/calculator/CompareChartLabel";
 
 const currentYear = new Date().getFullYear();
 const currentMonth = new Date().getMonth() + 1;
@@ -41,8 +42,10 @@ const ResultPageMain = () => {
 
   useEffect(() => {
     const getUserFetch = async () => {
-      const res = await getUserInfo(user.id);
-      setUserInfo(res);
+      if (user?.id) {
+        const res = await getUserInfo(user.id);
+        setUserInfo(res); // 이곳에서 반환되는 데이터가 `UserInfo` 타입이어야 합니다.
+      }
     };
 
     const fetchData = async () => {
@@ -83,7 +86,6 @@ const ResultPageMain = () => {
     );
   }
 
-  console.log(myAllData);
   return (
     <>
       <div className="bg-[#F2F9F2] min-h-full">
@@ -101,38 +103,11 @@ const ResultPageMain = () => {
             </div>
 
             {/* 나의 탄소 히스토리 최상단 데이터 */}
-            <div className="min-w-[320px] w-full  bg-white rounded-2xl border border-[#dcecdc] mb-[58px] md:px-[80px]">
-              <div className="flex flex-col md:flex-row w-full h-[200px] md:h-[140px] md:justify-between py-[20px] items-center">
-                <div className="flex items-center">
-                  <Image
-                    src={levelInfo.profile}
-                    alt="미리보기"
-                    width={114}
-                    height={84}
-                    className="w-[114px] h-[84px] rounded-[12px]"
-                  />
-                  <div className="ml-[31px]">
-                    <div className="text-[20px] md:text-[28px] font-semibold">
-                      {userInfo?.user_nickname}님
-                    </div>
-                  </div>
-                </div>
-
-                {/* 결과표 버튼 */}
-                <div className="mt-[28px] md:mt-0">
-                  <Link href="/calculator/result-list">
-                    <div className="flex w-[280px] h-[50px] md:w-[320px] md:h-[60px] bg-[#00320f] rounded-[40px] justify-center items-center gap-4 text-white ">
-                      <div className="text-[16px] md:text-[18px]">
-                        탄소 배출량 계산 결과표
-                      </div>
-                      <div className="text-[28px] md:text-[36px] font-semibold">
-                        {myAllData ? `${myAllData.length}건` : "0건"}
-                      </div>
-                    </div>
-                  </Link>
-                </div>
-              </div>
-            </div>
+            <CalculateUserCard
+              userInfo={userInfo}
+              myAllData={myAllData}
+              levelInfo={levelInfo}
+            />
 
             {/* 배출량 현황 */}
             <div>
@@ -141,208 +116,30 @@ const ResultPageMain = () => {
               </p>
               <div className="flex flex-col md:flex-row min-w-[320px] w-full h-[356px] md:h-[300px] rounded-[16px] justify-between items-center pt-[40px] py-[20px] px-[40px] md:px-[80px] mb-[12px] md:mb-[24px] bg-white border border-[#dcecdc]">
                 <div className="flex flex-col">
-                  <p className="text-black text-[24px] md:text-[36px] font-bold mb-[36px] leading-[1]">
-                    {userInfo?.user_nickname}님의 평균 배출량
-                  </p>
-                  <p className="text-[#0D9C36] text-[36px] md:text-[48px] font-semibold mb-[40px]">
-                    {myAllAvgData.toFixed(2)}kg
-                  </p>
-                  <div className="text-[14px] md:text-[16px] mb-[20px] md:mb-0">
-                    탄소 배출량이 평균 보다{" "}
-                    {userAvgData && myAllAvgData ? (
-                      myAllAvgData > 0 ? (
-                        Number(userAvgData) < myAllAvgData ? (
-                          <>
-                            {(
-                              (myAllAvgData / Number(userAvgData) - 1) *
-                              100
-                            ).toFixed(2)}{" "}
-                            % 높아요!
-                          </>
-                        ) : (
-                          <>
-                            {(
-                              (Number(userAvgData) / myAllAvgData - 1) *
-                              100
-                            ).toFixed(2)}{" "}
-                            % 낮아요!
-                          </>
-                        )
-                      ) : (
-                        <span>현재 평균 배출량이 계산되지 않았습니다.</span>
-                      )
-                    ) : null}
-                  </div>
+                  <EmissionLeftSide
+                    userNickname={userInfo?.user_nickname || ""}
+                    avgEmission={myAllAvgData}
+                    userAvgData={userAvgData}
+                    myAllAvgData={myAllAvgData}
+                  />
                 </div>
-
                 {/* 프로그레스바 */}
-                <div className="flex w-[270px] md:w-[500px] h-[128px] md:h-[220px] justify-center bg-[#F5F5F5] rounded-[14px] px-4">
-                  <div className="relative mt-[60px] md:mt-[115px]">
-                    {/* 프로그레스바 모양 */}
-                    <div className="flex flex-row gap-1">
-                      <div className="w-[50px] h-[10px] md:w-[88px] md:h-[16px] rounded-full bg-[#BFCEFE]" />
-                      <div className="w-[50px] h-[10px] md:w-[88px] md:h-[16px] rounded-full bg-[#9EB6FE]" />
-                      <div className="w-[50px] h-[10px] md:w-[88px] md:h-[16px] rounded-full bg-[#7E9DFD]" />
-                      <div className="w-[50px] h-[10px] md:w-[88px] md:h-[16px] rounded-full bg-[#5E85FD]" />
-                    </div>
-
-                    {/* 최저와 최고 텍스트 */}
-                    <div className="absolute left-0 top-[16px] md:top-[28px] text-[8px] md:text-[14px] text-gray-700 text-left">
-                      <div>최저</div>
-                      <div className="font-semibold">0 kg</div>
-                    </div>
-                    <div className="absolute right-0 top-[16px] md:top-[28px] text-[8px] md:text-[14px] text-gray-700 text-right">
-                      <div>최대</div>
-                      <div className="font-semibold">
-                        {userTopData?.carbon_emissions.toFixed(2)} kg
-                      </div>
-                    </div>
-
-                    {/* 프로그레스바 네이밍 */}
-                    <div
-                      className="absolute top-0 transform -translate-x-1/2 flex flex-col items-center"
-                      style={{
-                        left: `${
-                          userTopData?.carbon_emissions && myAllAvgData !== null // 이 두개의 값이 다 있을 때만 계산 시작
-                            ? // 위치 계산 시작
-                              Math.min(
-                                Math.max(
-                                  0,
-                                  (myAllAvgData /
-                                    userTopData?.carbon_emissions) *
-                                    100
-                                ),
-                                100
-                              ).toFixed(2)
-                            : 0
-                        }%`
-                      }}
-                    >
-                      <div className="relative top-[-30px] md:top-[-52px] w-[70px] h-[25px] md:min-w-[144px] md:h-[40px] rounded-full bg-black p-2">
-                        <div className="absolute flex justify-start items-center text-[8px] md:text-[14px] font-semibold top-[6px] md:top-[6px] text-white gap-[6px] md:gap-[10px]">
-                          <Image
-                            src={levelInfo.profileSmall}
-                            alt="내 레벨 이미지"
-                            width={28}
-                            height={28}
-                            className="w-[16px] md:w-[28px] rounded-[12px]"
-                          />
-                          <div>
-                            {/* 모바일에서는 4글자까지, md 이상에서는 6글자까지 표시 */}
-                            {userInfo?.user_nickname && (
-                              <span className="block md:hidden">
-                                {userInfo.user_nickname.length > 4
-                                  ? `${userInfo.user_nickname.slice(0, 4)}...`
-                                  : userInfo.user_nickname}
-                              </span>
-                            )}
-                            {userInfo?.user_nickname && (
-                              <span className="hidden md:block">
-                                {userInfo.user_nickname.length > 6
-                                  ? `${userInfo.user_nickname.slice(0, 6)}...`
-                                  : userInfo.user_nickname}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                      <div className="absolute top-[-3px] md:top-[-5px] z-5">
-                        <div
-                          className={`w-[15px] h-[15px] md:w-[26px] md:h-[26px] rounded-full flex items-center justify-center ${
-                            myAllAvgData &&
-                            userTopData?.carbon_emissions &&
-                            myAllAvgData / userTopData?.carbon_emissions < 0.25
-                              ? "bg-[#BFCEFE]"
-                              : userTopData?.carbon_emissions &&
-                                myAllAvgData / userTopData?.carbon_emissions <
-                                  0.5
-                              ? "bg-[#9EB6FE]"
-                              : userTopData?.carbon_emissions &&
-                                myAllAvgData / userTopData?.carbon_emissions <
-                                  0.75
-                              ? "bg-[#7E9DFD]"
-                              : "bg-[#5E85FD]"
-                          }`}
-                        >
-                          <div className="w-[8px] h-[8px] md:w-[14px] md:h-[14px] bg-white rounded-full" />
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      className="absolute top-[3px] transform -translate-x-1/2 flex flex-col items-center"
-                      style={{
-                        left: `${
-                          userTopData?.carbon_emissions && userAvgData !== null // 이 두개의 값이 다 있을 때만 계산 시작
-                            ? // 위치 계산 시작
-                              Math.min(
-                                Math.max(
-                                  0,
-                                  (Number(userAvgData) /
-                                    userTopData?.carbon_emissions) *
-                                    100
-                                ),
-                                100
-                              ).toFixed(2)
-                            : 0
-                        }%`
-                      }}
-                    >
-                      <div className="w-[5px] h-[5px] md:w-[10px] md:h-[10px] bg-white rounded-full" />
-                      <div className="flex flex-col items-center md:gap-1 text-[8px] md:text-[14px] text-gray-700">
-                        <div className="flex flex-col items-center bg-[#F5F5F5] mt-[6px] md:mt-[10px] px-3 py-0 rounded-md gap-[3px] z-2 leading-[1]">
-                          <div className="mt-[6px] py-0">평균</div>
-                          <div className="font-semibold">
-                            {userAvgData.toFixed(2)} kg
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+                <EmissionProgressBar
+                  myAllAvgData={myAllAvgData}
+                  userTopData={userTopData}
+                  userAvgData={userAvgData}
+                  levelInfo={levelInfo}
+                  userInfo={userInfo}
+                />
               </div>
             </div>
 
             {/* 나무 영역 */}
-            <div className="flex flex-col md:flex-row px] w-full h-[390px] md:h-[300px] rounded-[16px] justify-between items-center bg-[#00320F] px-[32px] py-[40px] md:px-[80px] mb-[58px] md:mb-[80px]">
-              <div className="flex-row-center gap-8">
-                <div className="flex flex-col">
-                  <p className="text-white text-[16px] md:text-[20px] font-bold mb-[24px]">
-                    지금까지 심은 나무
-                  </p>
-                  <div className="text-[#FFD64E] text-[36px] font-semibold mb-[28px] md:mb-[32px]">
-                    {myAllAvgData > 0
-                      ? (() => {
-                          const totalCarbonEmissions =
-                            myAllData?.reduce(
-                              (total, item) =>
-                                total + (item.carbon_emissions || 0),
-                              0
-                            ) || 0;
-
-                          const treeCount =
-                            (totalCarbonEmissions -
-                              (Number(userAvgData) || 0)) /
-                            22;
-
-                          return treeCount > 0
-                            ? `${treeCount.toFixed(2)} 그루`
-                            : "0 그루";
-                        })()
-                      : "0 그루"}
-                  </div>
-                  <p className="md:w-[450px] text-white text-[16px] mb-2 leading-[1.2]">
-                    평균 사용자보다 적게 배출한 탄소량을 나무의 연간 탄소
-                    흡수량과 비교해 나무로 환산해 보았어요!
-                  </p>
-                </div>
-              </div>
-              <Image
-                src={"/calculate/treeImg.svg"}
-                alt={"tree-image"}
-                width={400}
-                height={216}
-              />
-            </div>
+            <TreeCalculationCard
+              myAllAvgData={myAllAvgData}
+              myAllData={myAllData}
+              userAvgData={userAvgData}
+            />
 
             {/* 최근 5개월 배출량 추이 */}
             <div className="pb-[80px]">
@@ -350,18 +147,9 @@ const ResultPageMain = () => {
                 최근 5개월 배출량 추이
               </p>
 
-              {/* 기준값 */}
+              {/* 차트 라벨 */}
               <div className="flex flex-row gap-2 text-[12px] md:text-[14px] justify-end right-0 mt-[20px] relative">
-                <div className="flex flex-row absolute top-[20px] right-[20px] gap-4">
-                  <div className="flex flex-row gap-1 items-center">
-                    <div className="w-[14px] h-[14px] md:w-[18px] md:h-[18px] rounded-full bg-[#D5D7DD]" />
-                    <div>평균 배출량</div>
-                  </div>
-                  <div className="flex flex-row gap-1 items-center">
-                    <div className="w-[14px] h-[14px] md:w-[18px] md:h-[18px] rounded-full bg-[#FF7D6F]" />
-                    <div>나의 총 배출량</div>
-                  </div>
-                </div>
+                <CompareChartLabel />
               </div>
 
               {/* 차트 */}

--- a/src/components/calculator/CalculateUserCard.tsx
+++ b/src/components/calculator/CalculateUserCard.tsx
@@ -1,0 +1,61 @@
+import { MonthlyData } from "@/types/calculate";
+import Image from "next/image";
+import Link from "next/link";
+
+export interface MyInfo {
+  user_nickname?: string;
+  profile?: string;
+  levelInfo?: string;
+}
+
+interface CalculateUserCardProps {
+  userInfo: MyInfo | null; // userInfo는 null일 수 있음
+  myAllData: MonthlyData[] | null; // myAllData도 null일 수 있음
+  levelInfo: MyInfo | null;
+}
+
+const CalculateUserCard: React.FC<CalculateUserCardProps> = ({
+  userInfo,
+  myAllData,
+  levelInfo
+}) => {
+  // myAllData가 null일 경우 기본값 설정
+  const dataLength = myAllData ? myAllData.length : 0;
+
+  return (
+    <div className="min-w-[320px] w-full bg-white rounded-2xl border border-[#dcecdc] mb-[58px] md:px-[80px]">
+      <div className="flex flex-col md:flex-row w-full h-[200px] md:h-[140px] md:justify-between py-[20px] items-center">
+        <div className="flex items-center">
+          <Image
+            src={levelInfo?.profile || "/default-profile-image.jpg"} // 기본값 설정
+            alt="미리보기"
+            width={114}
+            height={84}
+            className="w-[114px] h-[84px] rounded-[12px]"
+          />
+          <div className="ml-[31px]">
+            <div className="text-[20px] md:text-[28px] font-semibold">
+              {userInfo?.user_nickname}님
+            </div>
+          </div>
+        </div>
+
+        {/* 결과표 버튼 */}
+        <div className="mt-[28px] md:mt-0">
+          <Link href="/calculator/result-list">
+            <div className="flex w-[280px] h-[50px] md:w-[320px] md:h-[60px] bg-[#00320f] rounded-[40px] justify-center items-center gap-4 text-white ">
+              <div className="text-[16px] md:text-[18px]">
+                탄소 배출량 계산 결과표
+              </div>
+              <div className="text-[28px] md:text-[36px] font-semibold">
+                {dataLength ? `${dataLength}건` : "0건"}
+              </div>
+            </div>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CalculateUserCard;

--- a/src/components/calculator/CompareChartLabel.tsx
+++ b/src/components/calculator/CompareChartLabel.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const CompareChartLabel = () => {
+  return (
+    <div className="flex flex-row absolute top-[20px] right-[20px] gap-4">
+      <div className="flex flex-row gap-1 items-center">
+        <div className="w-[14px] h-[14px] md:w-[18px] md:h-[18px] rounded-full bg-[#D5D7DD]" />
+        <div>평균 배출량</div>
+      </div>
+      <div className="flex flex-row gap-1 items-center">
+        <div className="w-[14px] h-[14px] md:w-[18px] md:h-[18px] rounded-full bg-[#FF7D6F]" />
+        <div>나의 총 배출량</div>
+      </div>
+    </div>
+  );
+};
+
+export default CompareChartLabel;

--- a/src/components/calculator/EmissionHeader.tsx
+++ b/src/components/calculator/EmissionHeader.tsx
@@ -1,0 +1,46 @@
+interface EmissionLeftSideProps {
+  userNickname: string;
+  avgEmission: number;
+  userAvgData: number | null;
+  myAllAvgData: number;
+}
+
+const EmissionLeftSide: React.FC<EmissionLeftSideProps> = ({
+  userNickname,
+  avgEmission,
+  userAvgData,
+  myAllAvgData
+}) => (
+  <>
+    <div>
+      <p className="text-black text-[24px] md:text-[36px] font-bold mb-[36px] leading-[1]">
+        {userNickname}님의 평균 배출량
+      </p>
+      <p className="text-[#0D9C36] text-[36px] md:text-[48px] font-semibold mb-[40px]">
+        {avgEmission.toFixed(2)}kg
+      </p>
+    </div>
+    <div className="text-[14px] md:text-[16px] mb-[20px] md:mb-0">
+      탄소 배출량이 평균 보다{" "}
+      {userAvgData && myAllAvgData ? (
+        myAllAvgData > 0 ? (
+          Number(userAvgData) < myAllAvgData ? (
+            <>
+              {((myAllAvgData / Number(userAvgData) - 1) * 100).toFixed(2)} %
+              높아요!
+            </>
+          ) : (
+            <>
+              {((Number(userAvgData) / myAllAvgData - 1) * 100).toFixed(2)} %
+              낮아요!
+            </>
+          )
+        ) : (
+          <span>현재 평균 배출량이 계산되지 않았습니다.</span>
+        )
+      ) : null}
+    </div>
+  </>
+);
+
+export default EmissionLeftSide;

--- a/src/components/calculator/EmissionProgressBar.tsx
+++ b/src/components/calculator/EmissionProgressBar.tsx
@@ -1,0 +1,149 @@
+import Image from "next/image";
+
+interface UserTopData {
+  user_id: string;
+  carbon_emissions: number;
+}
+
+interface LevelInfo {
+  profileSmall: string;
+}
+
+interface userInfo {
+  user_nickname: string;
+}
+
+interface EmissionProgressBarProps {
+  myAllAvgData: number;
+  userTopData: UserTopData | null;
+  userAvgData: number | 0;
+  levelInfo: LevelInfo;
+  userInfo: userInfo | null;
+}
+
+const EmissionProgressBar: React.FC<EmissionProgressBarProps> = ({
+  myAllAvgData,
+  userTopData,
+  userAvgData,
+  levelInfo,
+  userInfo
+}) => {
+  return (
+    <div className="flex w-[270px] md:w-[500px] h-[128px] md:h-[220px] justify-center bg-[#F5F5F5] rounded-[14px] px-4">
+      <div className="relative mt-[60px] md:mt-[115px]">
+        {/* 프로그레스바 모양 */}
+        <div className="flex flex-row gap-1">
+          <div className="w-[50px] h-[10px] md:w-[88px] md:h-[16px] rounded-full bg-[#BFCEFE]" />
+          <div className="w-[50px] h-[10px] md:w-[88px] md:h-[16px] rounded-full bg-[#9EB6FE]" />
+          <div className="w-[50px] h-[10px] md:w-[88px] md:h-[16px] rounded-full bg-[#7E9DFD]" />
+          <div className="w-[50px] h-[10px] md:w-[88px] md:h-[16px] rounded-full bg-[#5E85FD]" />
+        </div>
+
+        {/* 최저와 최고 텍스트 */}
+        <div className="absolute left-0 top-[16px] md:top-[28px] text-[8px] md:text-[14px] text-gray-700 text-left">
+          <div>최저</div>
+          <div className="font-semibold">0 kg</div>
+        </div>
+        <div className="absolute right-0 top-[16px] md:top-[28px] text-[8px] md:text-[14px] text-gray-700 text-right">
+          <div>최대</div>
+          <div className="font-semibold">
+            {userTopData?.carbon_emissions.toFixed(2)} kg
+          </div>
+        </div>
+
+        {/* 프로그레스바 네이밍 */}
+        <div
+          className="absolute top-0 transform -translate-x-1/2 flex flex-col items-center"
+          style={{
+            left: `${
+              userTopData?.carbon_emissions && myAllAvgData !== null
+                ? Math.min(
+                    Math.max(
+                      0,
+                      (myAllAvgData / userTopData?.carbon_emissions) * 100
+                    ),
+                    100
+                  ).toFixed(2)
+                : 0
+            }%`
+          }}
+        >
+          <div className="relative top-[-30px] md:top-[-52px] w-[70px] h-[25px] md:min-w-[144px] md:h-[40px] rounded-full bg-black p-2">
+            <div className="absolute flex justify-start items-center text-[8px] md:text-[14px] font-semibold top-[6px] md:top-[6px] text-white gap-[6px] md:gap-[10px]">
+              <Image
+                src={levelInfo.profileSmall}
+                alt="내 레벨 이미지"
+                width={28}
+                height={28}
+                className="w-[16px] md:w-[28px] rounded-[12px]"
+              />
+              <div>
+                {userInfo?.user_nickname && (
+                  <span className="block md:hidden">
+                    {userInfo.user_nickname.length > 4
+                      ? `${userInfo.user_nickname.slice(0, 4)}...`
+                      : userInfo.user_nickname}
+                  </span>
+                )}
+                {userInfo?.user_nickname && (
+                  <span className="hidden md:block">
+                    {userInfo.user_nickname.length > 6
+                      ? `${userInfo.user_nickname.slice(0, 6)}...`
+                      : userInfo.user_nickname}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="absolute top-[-3px] md:top-[-5px] z-5">
+            <div
+              className={`w-[15px] h-[15px] md:w-[26px] md:h-[26px] rounded-full flex items-center justify-center ${
+                myAllAvgData &&
+                userTopData?.carbon_emissions &&
+                myAllAvgData / userTopData?.carbon_emissions < 0.25
+                  ? "bg-[#BFCEFE]"
+                  : userTopData?.carbon_emissions &&
+                    myAllAvgData / userTopData?.carbon_emissions < 0.5
+                  ? "bg-[#9EB6FE]"
+                  : userTopData?.carbon_emissions &&
+                    myAllAvgData / userTopData?.carbon_emissions < 0.75
+                  ? "bg-[#7E9DFD]"
+                  : "bg-[#5E85FD]"
+              }`}
+            >
+              <div className="w-[8px] h-[8px] md:w-[14px] md:h-[14px] bg-white rounded-full" />
+            </div>
+          </div>
+        </div>
+        <div
+          className="absolute top-[3px] transform -translate-x-1/2 flex flex-col items-center"
+          style={{
+            left: `${
+              userTopData?.carbon_emissions && userAvgData !== null // 이 두개의 값이 다 있을 때만 계산 시작
+                ? // 위치 계산 시작
+                  Math.min(
+                    Math.max(
+                      0,
+                      (Number(userAvgData) / userTopData?.carbon_emissions) *
+                        100
+                    ),
+                    100
+                  ).toFixed(2)
+                : 0
+            }%`
+          }}
+        >
+          <div className="w-[5px] h-[5px] md:w-[10px] md:h-[10px] bg-white rounded-full" />
+          <div className="flex flex-col items-center md:gap-1 text-[8px] md:text-[14px] text-gray-700">
+            <div className="flex flex-col items-center bg-[#F5F5F5] mt-[6px] md:mt-[10px] px-3 py-0 rounded-md gap-[3px] z-2 leading-[1]">
+              <div className="mt-[6px] py-0">평균</div>
+              <div className="font-semibold">{userAvgData.toFixed(2)} kg</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EmissionProgressBar;

--- a/src/components/calculator/HistoryCompareCard.tsx
+++ b/src/components/calculator/HistoryCompareCard.tsx
@@ -57,12 +57,12 @@ const HistoryCompareCard: React.FC<HistoryCompareCardProps> = ({
   } else {
     comment = "데이터에 오류가 있습니다";
   }
-  console.log(
-    "thisMonthMyAvg, =>",
-    thisMonthMyAvg,
-    "LastMonthMyAvg, =>",
-    LastMonthMyAvg
-  );
+  // console.log(
+  //   "thisMonthMyAvg, =>",
+  //   thisMonthMyAvg,
+  //   "LastMonthMyAvg, =>",
+  //   LastMonthMyAvg
+  // );
 
   return (
     <>
@@ -91,7 +91,7 @@ const HistoryCompareCard: React.FC<HistoryCompareCardProps> = ({
                         {(
                           (thisMonthMyAvg / LastMonthMyAvg) * 100 -
                           100
-                        ).toFixed(2)}
+                        ).toFixed(0)}
                         %
                       </div>
                       <div className="ml-1">증가했어요!</div>
@@ -109,7 +109,7 @@ const HistoryCompareCard: React.FC<HistoryCompareCardProps> = ({
                         {(
                           (LastMonthMyAvg / thisMonthMyAvg) * 100 -
                           100
-                        ).toFixed(2)}
+                        ).toFixed(0)}
                         %
                       </div>
                       <div className="ml-1">감소했어요!</div>

--- a/src/components/calculator/TreeCalculationCard.tsx
+++ b/src/components/calculator/TreeCalculationCard.tsx
@@ -1,0 +1,56 @@
+import { MonthlyData } from "@/types/calculate";
+import Image from "next/image";
+
+interface TreeCalculationCardProps {
+  myAllAvgData: number;
+  myAllData: MonthlyData[] | null; // myAllData도 null일 수 있음
+  userAvgData: number | null;
+}
+
+const TreeCalculationCard: React.FC<TreeCalculationCardProps> = ({
+  myAllAvgData,
+  myAllData,
+  userAvgData
+}) => {
+  return (
+    <div className="flex flex-col md:flex-row px] w-full h-[390px] md:h-[300px] rounded-[16px] justify-between items-center bg-[#00320F] px-[32px] py-[40px] md:px-[80px] mb-[58px] md:mb-[80px]">
+      <div className="flex-row-center gap-8">
+        <div className="flex flex-col">
+          <p className="text-white text-[16px] md:text-[20px] font-bold mb-[24px]">
+            지금까지 심은 나무
+          </p>
+          <div className="text-[#FFD64E] text-[36px] font-semibold mb-[28px] md:mb-[32px]">
+            {myAllAvgData > 0
+              ? (() => {
+                  const totalCarbonEmissions =
+                    myAllData?.reduce(
+                      (total, item) => total + (item.carbon_emissions || 0),
+                      0
+                    ) || 0;
+
+                  const treeCount =
+                    (totalCarbonEmissions - (Number(userAvgData) || 0)) / 22;
+
+                  return treeCount > 0
+                    ? `${treeCount.toFixed(2)} 그루`
+                    : "0 그루";
+                })()
+              : "0 그루"}
+          </div>
+          <p className="md:w-[450px] text-white text-[16px] mb-2 leading-[1.2]">
+            평균 사용자보다 적게 배출한 탄소량을 나무의 연간 탄소 흡수량과
+            비교해 나무로 환산해 보았어요!
+          </p>
+        </div>
+      </div>
+      <Image
+        src={"/calculate/treeImg.svg"}
+        alt={"tree-image"}
+        width={400}
+        height={216}
+      />
+    </div>
+  );
+};
+
+export default TreeCalculationCard;


### PR DESCRIPTION
## 💁🏻‍♀️ 작업

- 탄소 계산기 부분에서 각 페이지에서 데이터를 불러왔는데 이 내용을 hooks, tanstack query로 가지고 오게 변경
- 퍼포먼스 및 리랜더링되는 버그 해결완료

<br>

## 🔥 작업 세부 내용

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

1. 로딩화면
로딩 화면이 너무 김 > 데이터를 불러오는데 문제가 있는 듯 함

2. 로딩 후 화면 이동
로딩 후 화면 이동 시 데이터가 제대로 들어가지 않고 순차적으로 들어어옴.
일단 데이터가 다 불러와지면 로딩화면에서 이동시켜지게 로직을 짜놨는데 그러지 못함.
`Promise.all`을 이용해서 모든 데이터들을 묶어줬는데도 이러한 오류가 발생

3. 화면 재로딩
크롬에서 탭을 통해 다른 곳으로 이동했다 오면 다시 로딩이 된다. 그럼 위의 로직을 다시 타게 됨


기존 데이터 불러오는 내용을 hooks와 tanstack query로 변경하여 중복적으로 데이터를 가지고 오거나 충돌이 나지 않아 데이터가 보다 빠르게 불러와 짐
병렬 처리와 캐싱으로 더 빠르게 데이터를 로딩 할 수 있게 변경을 해봤는데 확실히 엄청나게 많은 성능 개선이 됨.

퍼포먼스 점수 99점으로 상승

<br>

## 🚫 참고 사항

- x